### PR TITLE
Removed the command aliases from the module, manifest and tests

### DIFF
--- a/Tests/CompatibilitySession.Tests.ps1
+++ b/Tests/CompatibilitySession.Tests.ps1
@@ -17,14 +17,7 @@ Describe "Test the Windows PowerShell Compatibility Session functions" {
         @{command = 'Get-WinModule'},
         @{command = 'Import-WinModule'},
         @{command = 'Compare-WinModule'},
-        @{command = 'Copy-WinModule'},
-        @{command = 'awinfn'},
-        @{command = 'cpwinmo'},
-        @{command = 'cwinmo'},
-        @{command = 'gwinmo'},
-        @{command = 'ipwinmo'},
-        @{command = 'iwincm'},
-        @{command = 'inwinsn'}
+        @{command = 'Copy-WinModule'}
         ) {
             param($command)
             Get-Command $command | Should -Not -BeNullOrEmpty

--- a/WinCompatibilityPack/WinCompatibilityPack.psd1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psd1
@@ -77,17 +77,6 @@ CmdletsToExport = @()
 # Variables to export from this module
 VariablesToExport = @()
 
-# Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @(
-    'awinfn',
-    'cpwinmo',
-    'cwinmo',
-    'gwinmo',
-    'iwincm',
-    'ipwinmo',
-    'inwinsn'
-)
-
 # List of all modules packaged with this module
 # ModuleList = @()
 

--- a/WinCompatibilityPack/WinCompatibilityPack.psm1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psm1
@@ -119,7 +119,6 @@ $DefaultComputerName = 'localhost'
 function Initialize-WinSession
 {
     [CmdletBinding()]
-    [Alias("inwinsn")]
     [OutputType([System.Management.Automation.Runspaces.PSSession])]
     Param (
 
@@ -237,7 +236,6 @@ function Initialize-WinSession
 function Add-WinFunction
 {
     [CmdletBinding()]
-    [Alias("awinfn")]
     [OutputType([void])]
     Param
     (
@@ -319,7 +317,6 @@ function Add-WinFunction
 function Invoke-WinCommand
 {
     [CmdletBinding()]
-    [Alias('iwincm')]
     [OutputType([PSObject])]
     Param
     (
@@ -387,7 +384,6 @@ function Invoke-WinCommand
 function Get-WinModule
 {
     [CmdletBinding()]
-    [Alias("gwinmo")]
     [OutputType([PSObject])]
     Param
     (
@@ -490,7 +486,6 @@ function Get-WinModule
 function Import-WinModule
 {
     [CmdletBinding()]
-    [Alias("ipwinmo")]
     [OutputType([PSObject])]
     Param
     (
@@ -642,7 +637,6 @@ function Import-WinModule
 function Compare-WinModule
 {
     [CmdletBinding()]
-    [Alias("cwinmo")]
     [OutputType([PSObject])]
     Param
     (
@@ -726,7 +720,6 @@ function Compare-WinModule
 function Copy-WinModule
 {
     [CmdletBinding(SupportsShouldProcess)]
-    [Alias("cpwinmo")]
     [OutputType([void])]
     Param
     (


### PR DESCRIPTION
Since everyone agreed that the aliases were too long and that they really weren't needed, I've removed them. Fix for #2

closes #2 