### PR TITLE
Enable module to work on Windows PowerShell 5.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+CHANGELOG.md merge=union
+* text=auto
+*.png binary
+*.rtf binary

--- a/Build.ps1
+++ b/Build.ps1
@@ -1,0 +1,1 @@
+dotnet publish .\WinCompatibilityPack -c Release

--- a/Tests/CompatibilitySession.Tests.ps1
+++ b/Tests/CompatibilitySession.Tests.ps1
@@ -4,12 +4,14 @@
 using namespace System.Management.Automation
 using namespace System.Management.Automation.Runspaces
 
+$scriptPath = Split-Path $MyInvocation.MyCommand.Path -Parent
+
 Describe "Test the Windows PowerShell Compatibility Session functions" {
 
     BeforeAll {
-        Import-Module -Force ..\WinCompatibilityPack\WinCompatibilityPack.psd1
+        Import-Module -Force "$scriptPath\..\WinCompatibilityPack\bin\release\netstandard2.0\publish\WinCompatibilityPack.psd1"
     }
-    
+
     It "Make sure the <command> command exists" -TestCases @(
         @{command = 'Initialize-WinSession'},
         @{command = 'Add-WinFunction'},
@@ -29,7 +31,7 @@ Describe "Test the Windows PowerShell Compatibility Session functions" {
 
     It "Multiple calls to Initialize-WinSession shouild return the same session" {
         $first = Initialize-WinSession -PassThru
-        $second = Initialize-WinSession -PassThru 
+        $second = Initialize-WinSession -PassThru
         $first | Should -Be $second
     }
 

--- a/Tests/PSModulePath.Tests.ps1
+++ b/Tests/PSModulePath.Tests.ps1
@@ -1,9 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+$scriptPath = Split-Path $MyInvocation.MyCommand.Path -Parent
+
 Describe "Test Add-WindowsPSModulePath cmdlet" {
     BeforeAll {
-        Import-Module -Force ..\WinCompatibilityPack\WinCompatibilityPack.psd1
+        Import-Module -Force "$scriptPath\..\WinCompatibilityPack\bin\release\netstandard2.0\publish\WinCompatibilityPack.psd1"
         $originalPsModulePath = $env:PSModulePath
     }
 
@@ -12,10 +14,16 @@ Describe "Test Add-WindowsPSModulePath cmdlet" {
         $env:PSModulePath = $originalPsModulePath
     }
 
-    It "Validate Windows PSModulePath is added" {
+    It "Validate Windows PSModulePath is added on Core" -Skip:($PSVersionTable.PSEdition -ne "Core") {
         $env:PSModulePath | Should -Not -BeLike "*\WindowsPowerShell\*"
-        Add-WindowsPSModulePath
+        Add-WindowsPSModulePath | Should -BeNullOrEmpty
         $WindowsPSModulePath = [System.Environment]::GetEnvironmentVariable("psmodulepath", [System.EnvironmentVariableTarget]::Machine)
         $env:PSModulePath | Should -BeLike "*$WindowsPSModulePath*"
+    }
+
+    It "Validate Add-WindowsPSModulePath does nothing on Desktop" -Skip:($PSVersionTable.PSEdition -ne "Desktop") {
+        $currentPsModulePath = $env:PSModulePath
+        Add-WindowsPSModulePath | Should -BeNullOrEmpty
+        $env:PSModulePath | Should -BeExactly $currentPsModulePath
     }
 }

--- a/WinCompatibilityPack/WinCompatibilityPack.csproj
+++ b/WinCompatibilityPack/WinCompatibilityPack.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="2.0.0-rc1">
 
     </PackageReference>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.0.2">
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0-*">
         <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <None Include="WinCompatibilityPack.psd1" CopyToOutputDirectory="Always" />

--- a/WinCompatibilityPack/WinCompatibilityPack.psd1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psd1
@@ -135,13 +135,13 @@ This is the first release of this module with the basic commands:
     Copy-WinModule
 These commands provide a set of tools allowing you to run Windows PowerShell
 commands from PowerShell Core (PowerShell 6). See the help for the
-indivdual commands for examples on how to use this functionality.
+individual commands for examples on how to use this functionality.
 
-Additionall, the command `Add-WindowsPSModulePath` enables enumerating
+Additionally, the command `Add-WindowsPSModulePath` enables enumerating
 existing Windows PowerShell modules within PowerShell Core 6.
 
 The .Net Windows Compatibility Pack is included in this module exposing
-more .Net apis you can use with PowerShell.
+more .Net APIs you can use with PowerShell.
 '@
 
     } # End of PSData hashtable

--- a/WinCompatibilityPack/WinCompatibilityPack.psd1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psd1
@@ -14,7 +14,7 @@ RootModule = 'WinCompatibilityPack.psm1'
 ModuleVersion = '0.0.1'
 
 # Supported PSEditions
-CompatiblePSEditions = @('Core')
+CompatiblePSEditions = @('Desktop','Core')
 
 # ID used to uniquely identify this module
 GUID = '9d427bc5-2ae1-4806-b9d1-2ae62461767e'
@@ -30,56 +30,63 @@ Copyright = 'Copyright (c) Microsoft Corporation. All rights reserved'
 
 # Description of the functionality provided by this module
 Description = @'
-This module Provides compatibility utilities that allow PowerShell Core sessions to 
+This module Provides compatibility utilities that allow PowerShell Core sessions to
 invoke commands that are only available in Windows PowerShell. These utilities help you
 to discover available modules, import those modules through proxies and then use the module
 commands much as if they were native to PowerShell Core.
 '@
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '6.0'
-
-# Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# DotNetFrameworkVersion = ''
-
-# Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# CLRVersion = ''
-
-# Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
+PowerShellVersion = '5.1'
 
 # Assemblies that must be loaded prior to importing this module
 RequiredAssemblies = @(
+    'Microsoft.Win32.Registry.AccessControl.dll'
+    'Microsoft.Win32.Registry.dll'
     'Microsoft.Win32.SystemEvents.dll'
+    'System.Buffers.dll'
     'System.CodeDom.dll'
+    'System.ComponentModel.Composition.dll'
     'System.Configuration.ConfigurationManager.dll'
     'System.Data.DataSetExtensions.dll'
     'System.Data.Odbc.dll'
+    'System.Data.SqlClient.dll'
+    'System.Diagnostics.DiagnosticSource.dll'
     'System.Diagnostics.EventLog.dll'
     'System.Diagnostics.PerformanceCounter.dll'
     'System.DirectoryServices.AccountManagement.dll'
     'System.DirectoryServices.dll'
     'System.DirectoryServices.Protocols.dll'
     'System.Drawing.Common.dll'
+    'System.IO.FileSystem.AccessControl.dll'
+    'System.IO.Packaging.dll'
     'System.IO.Pipes.AccessControl.dll'
     'System.IO.Ports.dll'
     'System.Management.dll'
     'System.Memory.dll'
+    'System.Net.Http.WinHttpHandler.dll'
+    'System.Numerics.Vectors.dll'
+    'System.Reflection.DispatchProxy.dll'
     'System.Runtime.Caching.dll'
     'System.Runtime.CompilerServices.Unsafe.dll'
+    'System.Security.AccessControl.dll'
+    'System.Security.Cryptography.Cng.dll'
+    'System.Security.Cryptography.Pkcs.dll'
     'System.Security.Cryptography.ProtectedData.dll'
     'System.Security.Cryptography.Xml.dll'
+    'System.Security.Permissions.dll'
+    'System.Security.Principal.Windows.dll'
+    'System.ServiceModel.dll'
+    'System.ServiceModel.Duplex.dll'
+    'System.ServiceModel.Http.dll'
+    'System.ServiceModel.NetTcp.dll'
+    'System.ServiceModel.Primitives.dll'
+    'System.ServiceModel.Security.dll'
     'System.ServiceModel.Syndication.dll'
+    'System.ServiceProcess.ServiceController.dll'
+    'System.Text.Encoding.CodePages.dll'
+    'System.Threading.AccessControl.dll'
 )
-
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
-
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
-
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
@@ -99,12 +106,6 @@ CmdletsToExport = @()
 # Variables to export from this module
 VariablesToExport = @()
 
-# List of all modules packaged with this module
-# ModuleList = @()
-
-# List of all files packaged with this module
-# FileList = @()
-
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{
 
@@ -122,7 +123,7 @@ PrivateData = @{
         # A URL to an icon representing this module.
         # IconUri = ''
 
-        # ReleaseNotes of this module
+        # Release Notes of this module
         ReleaseNotes = @'
 This is the first release of this module with the basic commands:
     Initialize-WinSession
@@ -135,6 +136,12 @@ This is the first release of this module with the basic commands:
 These commands provide a set of tools allowing you to run Windows PowerShell
 commands from PowerShell Core (PowerShell 6). See the help for the
 indivdual commands for examples on how to use this functionality.
+
+Additionall, the command `Add-WindowsPSModulePath` enables enumerating
+existing Windows PowerShell modules within PowerShell Core 6.
+
+The .Net Windows Compatibility Pack is included in this module exposing
+more .Net apis you can use with PowerShell.
 '@
 
     } # End of PSData hashtable
@@ -143,8 +150,5 @@ indivdual commands for examples on how to use this functionality.
 
 # HelpInfo URI of this module
 # HelpInfoURI = ''
-
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''
 
 }

--- a/WinCompatibilityPack/WinCompatibilityPack.psm1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psm1
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-#requires -Version 6
-
 using namespace System.Management.Automation.
 using namespace System.Management.Automation.Runspaces
 
@@ -22,7 +20,7 @@ $NeverImportList = @(
 
 ###########################################################################################
 # The following is a list of modules native to PowerShell Core that don't have all of
-# the functionality of Windows PowerShell 5.1 versions. These modules can be imported but 
+# the functionality of Windows PowerShell 5.1 versions. These modules can be imported but
 # will not overwrite any existing PowerShell Core commands
 $NeverClobberList = @(
     "Microsoft.PowerShell.Management",
@@ -108,7 +106,7 @@ $DefaultComputerName = 'localhost'
    will be closed and a new session will be retrieved.
 
    This command is called by the other commands in this module so
-   you will rarely call this command directly. 
+   you will rarely call this command directly.
 .EXAMPLE
     Initialize-WinSession
     Initialize the default compatibility session
@@ -290,7 +288,7 @@ function Add-WinFunction
 .Synopsis
    Invoke a scriptblock that runs in the compatibility runspace.
 .DESCRIPTION
-    This command takes a scriptblock and invokes it in the 
+    This command takes a scriptblock and invokes it in the
     compatibility session. Parameters can be passed using the -ArgumentList
     parameter.
 
@@ -306,7 +304,7 @@ function Add-WinFunction
     5      1      17134  1        localhost
 
     In this example, we're invoking a scriptblock with 1 parameter in the compatibility
-    session. This scriptblock will simply print a message and then return 
+    session. This scriptblock will simply print a message and then return
     the version number of the compatibility session.
 .EXAMPLE
     Invoke-WinCommand {Get-EventLog -Log Application -New 10 }
@@ -344,7 +342,7 @@ function Invoke-WinCommand
         [Parameter()]
         [PSCredential]
             $Credential,
-        
+
         # Arguments to pass to the scriptblock
         [Parameter(ValueFromRemainingArguments)]
         [object[]]
@@ -378,7 +376,7 @@ function Invoke-WinCommand
     ----      ------- -----------
     PnpDevice 1.0.0.0
 
-    This example looks for modules in the compatibility session with the string 'PNP' 
+    This example looks for modules in the compatibility session with the string 'PNP'
     in their name.
 #>
 function Get-WinModule
@@ -411,10 +409,10 @@ function Get-WinModule
         [Parameter()]
         [PSCredential]
             $Credential,
-        
+
         # If specified, the complete deserialized module object
         # will be returned instead of the abbreviated form returned
-        # by default. 
+        # by default.
         [Parameter()]
         [Switch]
             $Full
@@ -423,7 +421,7 @@ function Get-WinModule
     [bool] $verboseFlag = $PSBoundParameters['Verbose']
 
     Write-Verbose -Verbose:$verboseFlag 'Connecting to compatibility session.'
-    $initializeWinSessionParameters = @{ 
+    $initializeWinSessionParameters = @{
         Verbose           = $verboseFlag
         ComputerName      = $ComputerName
         ConfigurationName = $ConfigurationName
@@ -431,7 +429,7 @@ function Get-WinModule
         PassThru          = $true
     }
     [PSSession] $session = Initialize-WinSession @initializeWinSessionParameters
-    
+
     if ($name -ne '*')
     {
         Write-Verbose -Verbose:$verboseFlag "Getting the list of available modules matching '$name'."
@@ -540,7 +538,7 @@ function Import-WinModule
         [Parameter()]
         [PSCredential]
             $Credential,
-        
+
         # If present, the ModuleInfo objects will be written to the output pipe
         # as deserialized (PSObject) objects
         [Parameter()]
@@ -551,7 +549,7 @@ function Import-WinModule
     [bool] $verboseFlag = $PSBoundParameters['Verbose']
 
     Write-Verbose -Verbose:$verboseFlag "Connecting to compatibility session."
-    $initializeWinSessionParameters = @{ 
+    $initializeWinSessionParameters = @{
         Verbose           = $verboseFlag
         ComputerName      = $ComputerName
         ConfigurationName = $ConfigurationName
@@ -567,25 +565,25 @@ function Import-WinModule
     $importNames = Invoke-Command -Session $session {
         # Running on the Remote Machine
         $m = (Get-Module -ListAvailable -Name $using:Name).
-                Where{ $_.Name -notin $using:NeverImportList } 
-        
+                Where{ $_.Name -notin $using:NeverImportList }
+
         # These can use wildcards e.g. Az*,x* will probably be common
         if ($using:Exclude)
-        { 
-            $m = $m.Where{ $_.Name -NotMatch $using:Exclude } 
+        {
+            $m = $m.Where{ $_.Name -NotMatch $using:Exclude }
         }
 
         $m.Name | Select-Object -Unique
     }
-    
+
     Write-Verbose -Verbose:$verboseFlag "Importing modules..."
     $importModuleParameters = @{
         Global              = $true
-        Force               = $Force 
+        Force               = $Force
         Verbose             = $verboseFlag
         PSSession           = $session
         PassThru            = $PassThru
-        DisableNameChecking = $DisableNameChecking 
+        DisableNameChecking = $DisableNameChecking
     }
     if ($Prefix)
     {
@@ -640,7 +638,7 @@ function Compare-WinModule
     [OutputType([PSObject])]
     Param
     (
-        # Specifies the names or name patterns of for the modules to compare. 
+        # Specifies the names or name patterns of for the modules to compare.
         # Wildcard characters are permitted.
         [Parameter(Position=0)]
         [String[]]
@@ -670,7 +668,7 @@ function Compare-WinModule
     [bool] $verboseFlag = $PSBoundParameters['Verbose']
 
     Write-Verbose -Verbose:$verboseFlag "Initializing compatibility session"
-    $initializeWinSessionParameters = @{ 
+    $initializeWinSessionParameters = @{
         Verbose           = $verboseFlag
         ComputerName      = $ComputerName
         ConfigurationName = $ConfigurationName
@@ -690,7 +688,7 @@ function Compare-WinModule
             Where{$_.Name -notin $using:NeverImportList -and $_.Name -like $using:Name} |
                 Select-Object Name, Version })
 
-    Write-Verbose -Verbose:$verboseFlag "Comparing module set..."     
+    Write-Verbose -Verbose:$verboseFlag "Comparing module set..."
     Compare-Object $LocalModule $RemoteModule -Property Name,Version |
         Where-Object SideIndicator -eq "=>"
 }
@@ -706,7 +704,7 @@ function Compare-WinModule
    just like the other native modules for PowerShell Core.
 
    Note that if there already is a module in the destination corresponding to the module
-   to be copied's name, it will not be copied. 
+   to be copied's name, it will not be copied.
 .EXAMPLE
     Copy-WinModule hyper-v -WhatIf -Verbose
 
@@ -723,7 +721,7 @@ function Copy-WinModule
     [OutputType([void])]
     Param
     (
-        # Specifies names or name patterns of modules that will be copied. 
+        # Specifies names or name patterns of modules that will be copied.
         # Wildcard characters are permitted.
         [Parameter(Mandatory=$false,Position=0)]
         [String[]]
@@ -748,7 +746,7 @@ function Copy-WinModule
         [Parameter()]
         [PSCredential]
             $Credential,
-        
+
         # The location where compatible modules should be copied to
         [Parameter()]
         [String]
@@ -870,9 +868,14 @@ C:\PS> Get-Module -ListAvailable
 function Add-WindowsPSModulePath
 {
 
-    if (-not $IsWindows)
+    if ($PSVersionTable.PSEdition -eq 'Core' -and -not $IsWindows)
     {
         throw "This cmdlet is only supported on Windows"
+    }
+
+    if ($PSVersionTable.PSEdition -eq 'Desktop')
+    {
+        return
     }
 
     $WindowsPSModulePath = [System.Environment]::GetEnvironmentVariable("psmodulepath", [System.EnvironmentVariableTarget]::Machine)


### PR DESCRIPTION
Need this module to work on Windows PowerShell 5.1 to enable PowerShell Modules built with .Net Std 2.0 and Windows Compat Pack work correctly.

Added .gitattributes so EOL is consistent
Added build.ps1
Updated tests to allow running from root of repo (or any folder)
Tests expect project to be built so that WCP assemblies are populated (hence running from publish folder)
Change reference to PS Std Lib 5.1 so that it builds correctly
Update psd1 to allow running on 5.1 and explicitly added all WCP assemblies so they are found in Windows PowerShell 5.1
Updated Add-WindowsPSModulePath to be no-op on Windows PowerShell and added test
VSCode fixed a bunch of trailing whitespace
