### PR TITLE
Move CBH to external help with PlatyPS

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,1 +1,2 @@
 dotnet publish .\WinCompatibilityPack -c Release
+New-ExternalHelp -OutputPath .\WinCompatibilityPack\bin\release\netstandard2.0\publish\ -Path .\docs\Module\

--- a/WinCompatibilityPack/WinCompatibilityPack.psm1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psm1
@@ -93,27 +93,6 @@ $DefaultConfigurationName = 'Microsoft.PowerShell'
 # Specifies the default name of the computer on which to create the compatibility session
 $DefaultComputerName = 'localhost'
 
-###########################################################################################
-<#
-.Synopsis
-   Initialize the connection to the compatibility session.
-.DESCRIPTION
-   Initialize the connection to the compatibility session. By default
-   the compatibility session will be created on the local host using the
-   'Microsoft.PowerShell' configuration. On subsequent calls, if a session
-   matching the current specification is found, it will be returned rather than
-   creating a new session. If a matching session is found, but can't be used, it
-   will be closed and a new session will be retrieved.
-
-   This command is called by the other commands in this module so
-   you will rarely call this command directly.
-.EXAMPLE
-    Initialize-WinSession
-    Initialize the default compatibility session
-.EXAMPLE
-    Initialize-WinSession -ComputerName localhost -ConfigurationName Microsoft.PowerShell
-    Initialize the compatibility session with a specific computer name and configuration
-#>
 function Initialize-WinSession
 {
     [CmdletBinding()]
@@ -210,27 +189,6 @@ function Initialize-WinSession
     }
 }
 
-###########################################################################################
-<#
-.Synopsis
-   This command defines a global function that always runs in the compatibility session.
-.DESCRIPTION
-    This command defines a global function that always runs in the compatibility session,
-    returning serialized data to the calling session. Parameters can be specified using
-    the 'param' statement but only positional parameters are supported.
-
-    By default, when executing, the current compatibility session is used,
-    or, in the case where there is no existing session, a new default session
-    will be created. This behaviour can be overridden using the
-    additional parameters on the command.
-.EXAMPLE
-    Add-WinFunction myFunction {param ($n) "Hi $n!"; $PSVersionTable.PSEdition }
-    This example defines a function called 'myFunction' with 1 parameter. When invoked it will print a message then return the PSVersion table
-    from the compatibility session. Now call the function
-    PS C:\> myFunction Bill
-    Hi Bill!
-    Desktop
-#>
 function Add-WinFunction
 {
     [CmdletBinding()]
@@ -283,35 +241,6 @@ function Add-WinFunction
     Set-item function:Global:$FunctionName $wrapper.GetNewClosure();
 }
 
-###########################################################################################
-<#
-.Synopsis
-   Invoke a scriptblock that runs in the compatibility runspace.
-.DESCRIPTION
-    This command takes a scriptblock and invokes it in the
-    compatibility session. Parameters can be passed using the -ArgumentList
-    parameter.
-
-    By default, when executing, the current compatibility session is used,
-    or, in the case where there is no existing session, a new default session
-    will be created. This behaviour can be overridden using the
-    additional parameters on the command.
-.EXAMPLE
-    Invoke-WinCommand {param ($name) "Hello $name, how are you?"; $PSVersionTable.PSVersion} Jeffrey
-    Hello Jeffrey, how are you?
-    Major  Minor  Build  Revision PSComputerName
-    -----  -----  -----  -------- --------------
-    5      1      17134  1        localhost
-
-    In this example, we're invoking a scriptblock with 1 parameter in the compatibility
-    session. This scriptblock will simply print a message and then return
-    the version number of the compatibility session.
-.EXAMPLE
-    Invoke-WinCommand {Get-EventLog -Log Application -New 10 }
-
-    This examples invokes Get-EventLog in the compatibility session,
-    returning the 10 newest events in the application log.
-#>
 function Invoke-WinCommand
 {
     [CmdletBinding()]
@@ -359,26 +288,6 @@ function Invoke-WinCommand
     Invoke-Command -Session $session -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList
 }
 
-###########################################################################################
-<#
-.Synopsis
-   Get a list of the available modules from the compatibility session
-.DESCRIPTION
-    Get a list of the available modules from the compatibility session.
-
-    By default, when executing, the current compatibility session is used,
-    or, in the case where there is no existing session, a new default session
-    will be created. This behaviour can be overridden using the
-    additional parameters on this command.
-.EXAMPLE
-    Get-WinModule *PNP*
-    Name      Version Description
-    ----      ------- -----------
-    PnpDevice 1.0.0.0
-
-    This example looks for modules in the compatibility session with the string 'PNP'
-    in their name.
-#>
 function Get-WinModule
 {
     [CmdletBinding()]
@@ -448,39 +357,6 @@ function Get-WinModule
         Sort-Object Name
 }
 
-###########################################################################################
-<#
-.Synopsis
-   Import a compatibility module.
-.DESCRIPTION
-    This command allows you to import proxy modules from a local or remote
-    session. These proxy modules will allow you to invoke cmdlets that are
-    not directly supported in this version of PowerShell. There are commands in
-    the Windows PowerShell core modules that don't exist natively in PowerShell Core.
-    If these modules are imported, proxies will only be created for the missing commands.
-    Commands that already exist in PowerShell core will not be overridden.
-
-    By default, when executing, the current compatibility session is used,
-    or, in the case where there is no existing session, a new default session
-    will be created. This behaviour can be overridden using the
-    additional parameters on the command.
-.EXAMPLE
-    Import-WinModule PnpDevice; Get-Command -Module PnpDevice
-
-    This example imports the 'PnpDevice' module.
-.EXAMPLE
-    Import-WinModule Microsoft.PowerShell.Management; Get-Command Get-EventLog
-
-    This example imports one of the core Windows PowerShell modules
-    containing commands not natively available in PowerShell Core such
-    as 'Get-EventLog'. Only commands not already present in PowerShell Core
-    will be imported.
-.EXAMPLE
-    Import-WinModule PnpDevice -Verbose -Force
-
-    This example forces a reload of the module 'PnpDevice' with
-    verbose output turned on.
-#>
 function Import-WinModule
 {
     [CmdletBinding()]
@@ -613,25 +489,6 @@ function Import-WinModule
     }
 }
 
-###########################################################################################
-<#
-.Synopsis
-    Compare the set of modules for this version of PowerShell
-    against those available in the comptibility session.
-.DESCRIPTION
-    Compare the set of modules for this version of PowerShell
-    against those available in the comptibility session.
-.EXAMPLE
-    Compare-WinModule
-
-    This will return a list of all of the modules available in the compatibility
-    session that are not currently available in the PowerShell Core environment
-.EXAMPLE
-    Compare-WinModule A*
-
-    This will return a list of all of the compatibility session modules matching
-    the wildcard pattern 'A*'
-#>
 function Compare-WinModule
 {
     [CmdletBinding()]
@@ -693,28 +550,6 @@ function Compare-WinModule
         Where-Object SideIndicator -eq "=>"
 }
 
-###########################################################################################
-<#
-.Synopsis
-   Copy modules from the compatibility session that are directly usable in PowerShell Core.
-.DESCRIPTION
-   Copy modules from the compatibility session that are directly usable in PowerShell Core.
-   By default, these modules will be copied to $PSHome/Modules. This can be overridden using
-   the -Destination parameter. Once these modules have been copied, they will be available
-   just like the other native modules for PowerShell Core.
-
-   Note that if there already is a module in the destination corresponding to the module
-   to be copied's name, it will not be copied.
-.EXAMPLE
-    Copy-WinModule hyper-v -WhatIf -Verbose
-
-    Run the copy command with -WhatIf to see what would be copied to $PSHome/Modules.
-    Also show Verose information.
-.EXAMPLE
-    PS C:\> Copy-WinModule hyper-v -Destination ~/Documents/PowerShell/Modules
-
-    Copy the specified module to your user module directory.
-#>
 function Copy-WinModule
 {
     [CmdletBinding(SupportsShouldProcess)]
@@ -834,36 +669,6 @@ function Copy-WinModule
         }
     }
 }
-
-###########################################################################################
-<#
-.SYNOPSIS
-
-Appends the existing Windows PowerShell PSModulePath to existing PSModulePath
-
-.DESCRIPTION
-
-If the current PSModulePath does not contain the Windows PowerShell PSModulePath, it will
-be appended to the end.
-
-.INPUTS
-
-None.
-
-.OUTPUTS
-
-None.
-
-.EXAMPLE
-
-C:\PS> Add-WindowsPSModulePath
-C:\PS> Import-Module Hyper-V
-
-.EXAMPLE
-
-C:\PS> Add-WindowsPSModulePath
-C:\PS> Get-Module -ListAvailable
-#>
 
 function Add-WindowsPSModulePath
 {

--- a/docs/Module/Add-WinFunction.md
+++ b/docs/Module/Add-WinFunction.md
@@ -1,0 +1,149 @@
+---
+external help file: WinCompatibilityPack-help.xml
+Module Name: WinCompatibilityPack
+online version:
+schema: 2.0.0
+---
+
+# Add-WinFunction
+
+## SYNOPSIS
+
+This command defines a global function that always runs in the compatibility session.
+
+## SYNTAX
+
+```none
+Add-WinFunction [-FunctionName] <String> [-ScriptBlock] <ScriptBlock> [-ComputerName <String>]
+ [-ConfigurationName <String>] [-Credential <PSCredential>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This command defines a global function that always runs in the compatibility session,
+returning serialized data to the calling session.
+Parameters can be specified using the 'param' statement but only positional parameters are supported.
+
+By default, when executing, the current compatibility session is used,
+or, in the case where there is no existing session, a new default session will be created.
+This behavior can be overridden using the additional parameters on the command.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Add-WinFunction myFunction {param ($n) "Hi $n!"; $PSVersionTable.PSEdition }
+```
+
+This example defines a function called 'myFunction' with 1 parameter.
+When invoked it will print a message then return the PSVersion table from the compatibility session.
+
+Now call the function
+
+```none
+PS C:\> myFunction Bill
+Hi Bill!
+Desktop
+```
+
+## PARAMETERS
+
+### -ComputerName
+
+If you don't want to use the default compatibility session,
+use this parameter to specify the name of the computer on which to create the compatibility session.
+(Defaults to 'localhost')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Cn
+
+Required: False
+Position: Named
+Default value: localhost
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConfigurationName
+
+Specifies the configuration to connect to when creating the compatibility session.
+(Defaults to 'Microsoft.PowerShell')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 'Microsoft.PowerShell
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+The credential to use when creating the compatibility session
+using the target machine/configuration
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FunctionName
+
+The name of the function to define.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScriptBlock
+
+ScriptBlock to use as the body of the function.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Void
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Module/Add-WinFunction.md
+++ b/docs/Module/Add-WinFunction.md
@@ -13,7 +13,7 @@ This command defines a global function that always runs in the compatibility ses
 
 ## SYNTAX
 
-```none
+```
 Add-WinFunction [-FunctionName] <String> [-ScriptBlock] <ScriptBlock> [-ComputerName <String>]
  [-ConfigurationName <String>] [-Credential <PSCredential>] [<CommonParameters>]
 ```
@@ -41,7 +41,7 @@ When invoked it will print a message then return the PSVersion table from the co
 
 Now call the function
 
-```none
+```
 PS C:\> myFunction Bill
 Hi Bill!
 Desktop

--- a/docs/Module/Add-WinFunction.md
+++ b/docs/Module/Add-WinFunction.md
@@ -34,18 +34,16 @@ This behavior can be overridden using the additional parameters on the command.
 
 ```powershell
 Add-WinFunction myFunction {param ($n) "Hi $n!"; $PSVersionTable.PSEdition }
+myFunction Bill
+```
+
+```
+Hi Bill!
+Desktop
 ```
 
 This example defines a function called 'myFunction' with 1 parameter.
 When invoked it will print a message then return the PSVersion table from the compatibility session.
-
-Now call the function
-
-```
-PS C:\> myFunction Bill
-Hi Bill!
-Desktop
-```
 
 ## PARAMETERS
 

--- a/docs/Module/Add-WindowsPSModulePath.md
+++ b/docs/Module/Add-WindowsPSModulePath.md
@@ -13,7 +13,7 @@ Appends the existing Windows PowerShell PSModulePath to existing PSModulePath
 
 ## SYNTAX
 
-```none
+```
 Add-WindowsPSModulePath
 ```
 

--- a/docs/Module/Add-WindowsPSModulePath.md
+++ b/docs/Module/Add-WindowsPSModulePath.md
@@ -1,0 +1,53 @@
+---
+external help file: WinCompatibilityPack-help.xml
+Module Name: WinCompatibilityPack
+online version:
+schema: 2.0.0
+---
+
+# Add-WindowsPSModulePath
+
+## SYNOPSIS
+
+Appends the existing Windows PowerShell PSModulePath to existing PSModulePath
+
+## SYNTAX
+
+```none
+Add-WindowsPSModulePath
+```
+
+## DESCRIPTION
+
+If the current PSModulePath does not contain the Windows PowerShell PSModulePath,
+it will be appended to the end.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Add-WindowsPSModulePath
+Import-Module Hyper-V
+```
+
+### EXAMPLE 2
+
+```powershell
+Add-WindowsPSModulePath
+Get-Module -ListAvailable
+```
+
+## PARAMETERS
+
+## INPUTS
+
+### None.
+
+## OUTPUTS
+
+### None.
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Module/Add-WindowsPSModulePath.md
+++ b/docs/Module/Add-WindowsPSModulePath.md
@@ -14,7 +14,7 @@ Appends the existing Windows PowerShell PSModulePath to existing PSModulePath
 ## SYNTAX
 
 ```
-Add-WindowsPSModulePath
+Add-WindowsPSModulePath [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/docs/Module/Compare-WinModule.md
+++ b/docs/Module/Compare-WinModule.md
@@ -13,7 +13,7 @@ Compare the set of modules for this version of PowerShell against those availabl
 
 ## SYNTAX
 
-```none
+```
 Compare-WinModule [[-Name] <String[]>] [-ComputerName <String>] [-ConfigurationName <String>]
  [-Credential <PSCredential>] [<CommonParameters>]
 ```

--- a/docs/Module/Compare-WinModule.md
+++ b/docs/Module/Compare-WinModule.md
@@ -1,0 +1,127 @@
+---
+external help file: WinCompatibilityPack-help.xml
+Module Name: WinCompatibilityPack
+online version:
+schema: 2.0.0
+---
+
+# Compare-WinModule
+
+## SYNOPSIS
+
+Compare the set of modules for this version of PowerShell against those available in the compatibility session.
+
+## SYNTAX
+
+```none
+Compare-WinModule [[-Name] <String[]>] [-ComputerName <String>] [-ConfigurationName <String>]
+ [-Credential <PSCredential>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Compare the set of modules for this version of PowerShell against those available in the compatibility session.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Compare-WinModule
+```
+
+This will return a list of all of the modules available in the compatibility session
+that are not currently available in the PowerShell Core environment.
+
+### EXAMPLE 2
+
+```powershell
+Compare-WinModule A*
+```
+
+This will return a list of all of the compatibility session modules matching the wildcard pattern 'A*'.
+
+## PARAMETERS
+
+### -ComputerName
+
+If you don't want to use the default compatibility session,
+use this parameter to specify the name of the computer on which to create the compatibility session.
+(Defaults to 'localhost')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: cn
+
+Required: False
+Position: Named
+Default value: localhost
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConfigurationName
+
+Specifies the configuration to connect to when creating the compatibility session.
+(Defaults to 'Microsoft.PowerShell')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Microsoft.PowerShell
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+If needed, use this parameter to specify credentials for the compatibility session.
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+
+Specifies the names or name patterns of for the modules to compare.
+Wildcard characters are permitted.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: *
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Management.Automation.PSObject
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Module/Copy-WinModule.md
+++ b/docs/Module/Copy-WinModule.md
@@ -13,7 +13,7 @@ Copy modules from the compatibility session that are directly usable in PowerShe
 
 ## SYNTAX
 
-```none
+```
 Copy-WinModule [[-Name] <String[]>] [-ComputerName <String>] [-ConfigurationName <String>]
  [-Credential <PSCredential>] [-Destination <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```

--- a/docs/Module/Copy-WinModule.md
+++ b/docs/Module/Copy-WinModule.md
@@ -1,0 +1,183 @@
+---
+external help file: WinCompatibilityPack-help.xml
+Module Name: WinCompatibilityPack
+online version:
+schema: 2.0.0
+---
+
+# Copy-WinModule
+
+## SYNOPSIS
+
+Copy modules from the compatibility session that are directly usable in PowerShell Core.
+
+## SYNTAX
+
+```none
+Copy-WinModule [[-Name] <String[]>] [-ComputerName <String>] [-ConfigurationName <String>]
+ [-Credential <PSCredential>] [-Destination <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Copy modules from the compatibility session that are directly usable in PowerShell Core.
+By default, these modules will be copied to $PSHome/Modules.
+This can be overridden using the -Destination parameter.
+Once these modules have been copied,
+they will be available just like the other native modules for PowerShell Core.
+
+Note that if there already is a module in the destination corresponding to the module
+to be copied's name, it will not be copied.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Copy-WinModule hyper-v -WhatIf -Verbose
+```
+
+Run the copy command with -WhatIf to see what would be copied to $PSHome/Modules.
+Also show Verbose information.
+
+### EXAMPLE 2
+
+```powershell
+Copy-WinModule hyper-v -Destination ~/Documents/PowerShell/Modules
+```
+
+Copy the specified module to your user module directory.
+
+## PARAMETERS
+
+### -ComputerName
+
+If you don't want to use the default compatibility session,
+use this parameter to specify the name of the computer on which to create the compatibility session.
+(Defaults to 'localhost')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: cn
+
+Required: False
+Position: Named
+Default value: localhost
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConfigurationName
+
+Specifies the configuration to connect to when creating the compatibility session
+(Defaults to 'Microsoft.PowerShell')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Microsoft.PowerShell
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+If needed, use this parameter to specify credentials for the compatibility session
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Destination
+
+The location where compatible modules should be copied to
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+
+Specifies names or name patterns of modules that will be copied.
+Wildcard characters are permitted.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: *
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Void
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Module/Get-WinModule.md
+++ b/docs/Module/Get-WinModule.md
@@ -1,0 +1,144 @@
+---
+external help file: WinCompatibilityPack-help.xml
+Module Name: WinCompatibilityPack
+online version:
+schema: 2.0.0
+---
+
+# Get-WinModule
+
+## SYNOPSIS
+
+Get a list of the available modules from the compatibility session
+
+## SYNTAX
+
+```none
+Get-WinModule [[-Name] <String[]>] [-ComputerName <String>] [-ConfigurationName <String>]
+ [-Credential <PSCredential>] [-Full] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Get a list of the available modules from the compatibility session.
+
+By default, when executing, the current compatibility session is used,
+or, in the case where there is no existing session,
+a new default session will be created.
+This behavior can be overridden using the additional parameters on this command.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Get-WinModule *PNP*
+```
+
+```none
+Name      Version Description
+----      ------- -----------
+PnpDevice 1.0.0.0
+```
+
+This example looks for modules in the compatibility session with the string 'PNP' in their name.
+
+## PARAMETERS
+
+### -ComputerName
+
+If you don't want to use the default compatibility session,
+use this parameter to specify the name of the computer on which to create the compatibility session.
+(Defaults to 'localhost')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: cn
+
+Required: False
+Position: Named
+Default value: localhost
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConfigurationName
+
+Specifies the configuration to connect to when creating the compatibility session
+(Defaults to 'Microsoft.PowerShell')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Microsoft.PowerShell
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+The credential to use when creating the compatibility session using the target machine/configuration
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Full
+
+If specified, the complete deserialized module object will be returned instead of the abbreviated form returned by default.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+
+Pattern to filter module names by.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: *
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Management.Automation.PSObject
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Module/Get-WinModule.md
+++ b/docs/Module/Get-WinModule.md
@@ -13,7 +13,7 @@ Get a list of the available modules from the compatibility session
 
 ## SYNTAX
 
-```none
+```
 Get-WinModule [[-Name] <String[]>] [-ComputerName <String>] [-ConfigurationName <String>]
  [-Credential <PSCredential>] [-Full] [<CommonParameters>]
 ```

--- a/docs/Module/Import-WinModule.md
+++ b/docs/Module/Import-WinModule.md
@@ -1,0 +1,243 @@
+---
+external help file: WinCompatibilityPack-help.xml
+Module Name: WinCompatibilityPack
+online version:
+schema: 2.0.0
+---
+
+# Import-WinModule
+
+## SYNOPSIS
+
+Import a compatibility module.
+
+## SYNTAX
+
+```none
+Import-WinModule [[-Name] <String[]>] [-Exclude <String[]>] [-ComputerName <String>]
+ [-ConfigurationName <String>] [-Prefix <String>] [-DisableNameChecking] [-NoClobber] [-Force]
+ [-Credential <PSCredential>] [-PassThru] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This command allows you to import proxy modules from a local or remote session.
+These proxy modules will allow you to invoke cmdlets that are not directly supported in this version of PowerShell.
+There are commands in the Windows PowerShell core modules that don't exist natively in PowerShell Core.
+If these modules are imported, proxies will only be created for the missing commands.
+Commands that already exist in PowerShell core will not be overridden.
+
+By default, when executing, the current compatibility session is used,
+or, in the case where there is no existing session, a new default session will be created.
+This behavior can be overridden using the additional parameters on the command.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Import-WinModule PnpDevice; Get-Command -Module PnpDevice
+```
+
+This example imports the 'PnpDevice' module.
+
+### EXAMPLE 2
+
+```powershell
+Import-WinModule Microsoft.PowerShell.Management; Get-Command Get-EventLog
+```
+
+This example imports one of the core Windows PowerShell modules containing commands
+not natively available in PowerShell Core such as 'Get-EventLog'.
+Only commands not already present in PowerShell Core will be imported.
+
+### EXAMPLE 3
+
+```powershell
+Import-WinModule PnpDevice -Verbose -Force
+```
+
+This example forces a reload of the module 'PnpDevice' with verbose output turned on.
+
+## PARAMETERS
+
+### -ComputerName
+
+If you don't want to use the default compatibility session, use
+this parameter to specify the name of the computer on which to create
+the compatibility session.
+(Defaults to 'localhost')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: cn
+
+Required: False
+Position: Named
+Default value: localhost
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConfigurationName
+
+Specifies the configuration to connect to when creating the compatibility session
+(Defaults to 'Microsoft.PowerShell')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Microsoft.PowerShell
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+The credential to use when creating the compatibility session using the target machine/configuration
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableNameChecking
+
+Disable warnings about non-standard verbs
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Exclude
+
+A list of wildcard patterns matching the names of modules that
+should not be imported.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+Force reloading the module
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+
+Specifies the name of the module to be imported.
+Wildcards can be used.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: *
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoClobber
+
+Don't overwrite any existing function definitions.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+
+If present, the ModuleInfo objects will be written to the output pipe as deserialized (PSObject) objects.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Prefix
+
+Prefix to prepend to the imported command names
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Management.Automation.PSObject
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Module/Import-WinModule.md
+++ b/docs/Module/Import-WinModule.md
@@ -13,7 +13,7 @@ Import a compatibility module.
 
 ## SYNTAX
 
-```none
+```
 Import-WinModule [[-Name] <String[]>] [-Exclude <String[]>] [-ComputerName <String>]
  [-ConfigurationName <String>] [-Prefix <String>] [-DisableNameChecking] [-NoClobber] [-Force]
  [-Credential <PSCredential>] [-PassThru] [<CommonParameters>]

--- a/docs/Module/Initialize-WinSession.md
+++ b/docs/Module/Initialize-WinSession.md
@@ -1,0 +1,133 @@
+---
+external help file: WinCompatibilityPack-help.xml
+Module Name: WinCompatibilityPack
+online version:
+schema: 2.0.0
+---
+
+# Initialize-WinSession
+
+## SYNOPSIS
+
+Initialize the connection to the compatibility session.
+
+## SYNTAX
+
+```none
+Initialize-WinSession [[-ComputerName] <String>] [-ConfigurationName <String>] [-Credential <PSCredential>]
+ [-PassThru] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Initialize the connection to the compatibility session.
+By default the compatibility session will be created on the localhost using the 'Microsoft.PowerShell' configuration.
+On subsequent calls, if a session matching the current specification is found,
+it will be returned rather than creating a new session.
+If a matching session is found, but can't be used,
+it will be closed and a new session will be retrieved.
+
+This command is called by the other commands in this module so you will rarely call this command directly.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Initialize-WinSession
+```
+
+Initialize the default compatibility session.
+
+### EXAMPLE 2
+
+```powershell
+Initialize-WinSession -ComputerName localhost -ConfigurationName Microsoft.PowerShell
+```
+
+Initialize the compatibility session with a specific computer name and configuration
+
+## PARAMETERS
+
+### -ComputerName
+
+If you don't want to use the default compatibility session, use
+this parameter to specify the name of the computer on which to create
+the compatibility session.
+(Defaults to 'localhost')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Cn
+
+Required: False
+Position: 1
+Default value: localhost
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConfigurationName
+
+Specifies the configuration to connect to when creating the compatibility session
+(Defaults to 'Microsoft.PowerShell')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: $script:DefaultConfigurationName
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+The credential to use when connecting to the target machine/configuration
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+
+If present, the specified session object will be returned
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Management.Automation.Runspaces.PSSession
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Module/Initialize-WinSession.md
+++ b/docs/Module/Initialize-WinSession.md
@@ -13,7 +13,7 @@ Initialize the connection to the compatibility session.
 
 ## SYNTAX
 
-```none
+```
 Initialize-WinSession [[-ComputerName] <String>] [-ConfigurationName <String>] [-Credential <PSCredential>]
  [-PassThru] [<CommonParameters>]
 ```

--- a/docs/Module/Invoke-WinCommand.md
+++ b/docs/Module/Invoke-WinCommand.md
@@ -13,7 +13,7 @@ Invoke a ScriptBlock that runs in the compatibility runspace.
 
 ## SYNTAX
 
-```none
+```
 Invoke-WinCommand [-ScriptBlock] <ScriptBlock> [-ComputerName <String>] [-ConfigurationName <String>]
  [-Credential <PSCredential>] [-ArgumentList <Object[]>] [<CommonParameters>]
 ```

--- a/docs/Module/Invoke-WinCommand.md
+++ b/docs/Module/Invoke-WinCommand.md
@@ -1,0 +1,155 @@
+---
+external help file: WinCompatibilityPack-help.xml
+Module Name: WinCompatibilityPack
+online version:
+schema: 2.0.0
+---
+
+# Invoke-WinCommand
+
+## SYNOPSIS
+
+Invoke a ScriptBlock that runs in the compatibility runspace.
+
+## SYNTAX
+
+```none
+Invoke-WinCommand [-ScriptBlock] <ScriptBlock> [-ComputerName <String>] [-ConfigurationName <String>]
+ [-Credential <PSCredential>] [-ArgumentList <Object[]>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This command takes a ScriptBlock and invokes it in the compatibility session.
+Parameters can be passed using the -ArgumentList parameter.
+
+By default, when executing, the current compatibility session is used,
+or, in the case where there is no existing session, a new default session will be created.
+This behavior can be overridden using the additional parameters on the command.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Invoke-WinCommand {param ($name) "Hello $name, how are you?"; $PSVersionTable.PSVersion} Jeffrey
+```
+
+```none
+Hello Jeffrey, how are you?
+Major  Minor  Build  Revision PSComputerName
+-----  -----  -----  -------- --------------
+5      1      17134  1        localhost
+```
+
+In this example, we're invoking a ScriptBlock with 1 parameter in the compatibility session.
+This ScriptBlock will simply print a message and then return the version number of the compatibility session.
+
+### EXAMPLE 2
+
+```powershell
+Invoke-WinCommand {Get-EventLog -Log Application -New 10 }
+```
+
+This examples invokes Get-EventLog in the compatibility session,
+returning the 10 newest events in the application log.
+
+## PARAMETERS
+
+### -ArgumentList
+
+Arguments to pass to the ScriptBlock.
+
+```yaml
+Type: Object[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ComputerName
+
+If you don't want to use the default compatibility session,
+use this parameter to specify the name of the computer on which to create the compatibility session.
+(Defaults to 'localhost')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: cn
+
+Required: False
+Position: Named
+Default value: localhost
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConfigurationName
+
+Specifies the configuration to connect to when creating the compatibility session
+(Defaults to 'Microsoft.PowerShell')
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Microsoft.PowerShell
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+The credential to use when connecting to the compatibility session.
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScriptBlock
+
+The ScriptBlock to invoke in the compatibility session.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Management.Automation.PSObject
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Module/WinCompatibilityPack.md
+++ b/docs/Module/WinCompatibilityPack.md
@@ -1,37 +1,47 @@
 ---
 Module Name: WinCompatibilityPack
 Module Guid: 9d427bc5-2ae1-4806-b9d1-2ae62461767e
-Download Help Link: {{Please enter FwLink manually}}
-Help Version: {{Please enter version of help manually (X.X.X.X) format}}
+Download Help Link:
+Help Version: 0.0.0.1
 Locale: en-US
 ---
 
 # WinCompatibilityPack Module
+
 ## Description
-{{Manually Enter Description Here}}
+
+This module provides PowerShell Core 6 compatibility with existing Windows PowerShell scripts.
 
 ## WinCompatibilityPack Cmdlets
+
 ### [Add-WindowsPSModulePath](Add-WindowsPSModulePath.md)
+
 Appends the existing Windows PowerShell PSModulePath to existing PSModulePath
 
 ### [Add-WinFunction](Add-WinFunction.md)
+
 This command defines a global function that always runs in the compatibility session.
 
 ### [Compare-WinModule](Compare-WinModule.md)
+
 Compare the set of modules for this version of PowerShell against those available in the compatibility session.
 
 ### [Copy-WinModule](Copy-WinModule.md)
+
 Copy modules from the compatibility session that are directly usable in PowerShell Core.
 
 ### [Get-WinModule](Get-WinModule.md)
+
 Get a list of the available modules from the compatibility session
 
 ### [Import-WinModule](Import-WinModule.md)
+
 Import a compatibility module.
 
 ### [Initialize-WinSession](Initialize-WinSession.md)
+
 Initialize the connection to the compatibility session.
 
 ### [Invoke-WinCommand](Invoke-WinCommand.md)
-Invoke a ScriptBlock that runs in the compatibility runspace.
 
+Invoke a ScriptBlock that runs in the compatibility runspace.

--- a/docs/Module/WinCompatibilityPack.md
+++ b/docs/Module/WinCompatibilityPack.md
@@ -12,26 +12,26 @@ Locale: en-US
 
 ## WinCompatibilityPack Cmdlets
 ### [Add-WindowsPSModulePath](Add-WindowsPSModulePath.md)
-{{Manually Enter Add-WindowsPSModulePath Description Here}}
+Appends the existing Windows PowerShell PSModulePath to existing PSModulePath
 
 ### [Add-WinFunction](Add-WinFunction.md)
-{{Manually Enter Add-WinFunction Description Here}}
+This command defines a global function that always runs in the compatibility session.
 
 ### [Compare-WinModule](Compare-WinModule.md)
-{{Manually Enter Compare-WinModule Description Here}}
+Compare the set of modules for this version of PowerShell against those available in the compatibility session.
 
 ### [Copy-WinModule](Copy-WinModule.md)
-{{Manually Enter Copy-WinModule Description Here}}
+Copy modules from the compatibility session that are directly usable in PowerShell Core.
 
 ### [Get-WinModule](Get-WinModule.md)
-{{Manually Enter Get-WinModule Description Here}}
+Get a list of the available modules from the compatibility session
 
 ### [Import-WinModule](Import-WinModule.md)
-{{Manually Enter Import-WinModule Description Here}}
+Import a compatibility module.
 
 ### [Initialize-WinSession](Initialize-WinSession.md)
-{{Manually Enter Initialize-WinSession Description Here}}
+Initialize the connection to the compatibility session.
 
 ### [Invoke-WinCommand](Invoke-WinCommand.md)
-{{Manually Enter Invoke-WinCommand Description Here}}
+Invoke a ScriptBlock that runs in the compatibility runspace.
 

--- a/docs/Module/WinCompatibilityPack.md
+++ b/docs/Module/WinCompatibilityPack.md
@@ -1,0 +1,37 @@
+---
+Module Name: WinCompatibilityPack
+Module Guid: 9d427bc5-2ae1-4806-b9d1-2ae62461767e
+Download Help Link: {{Please enter FwLink manually}}
+Help Version: {{Please enter version of help manually (X.X.X.X) format}}
+Locale: en-US
+---
+
+# WinCompatibilityPack Module
+## Description
+{{Manually Enter Description Here}}
+
+## WinCompatibilityPack Cmdlets
+### [Add-WindowsPSModulePath](Add-WindowsPSModulePath.md)
+{{Manually Enter Add-WindowsPSModulePath Description Here}}
+
+### [Add-WinFunction](Add-WinFunction.md)
+{{Manually Enter Add-WinFunction Description Here}}
+
+### [Compare-WinModule](Compare-WinModule.md)
+{{Manually Enter Compare-WinModule Description Here}}
+
+### [Copy-WinModule](Copy-WinModule.md)
+{{Manually Enter Copy-WinModule Description Here}}
+
+### [Get-WinModule](Get-WinModule.md)
+{{Manually Enter Get-WinModule Description Here}}
+
+### [Import-WinModule](Import-WinModule.md)
+{{Manually Enter Import-WinModule Description Here}}
+
+### [Initialize-WinSession](Initialize-WinSession.md)
+{{Manually Enter Initialize-WinSession Description Here}}
+
+### [Invoke-WinCommand](Invoke-WinCommand.md)
+{{Manually Enter Invoke-WinCommand Description Here}}
+


### PR DESCRIPTION
```powershell
New-MarkdownHelp -Module WinCompatibilityPack -AlphabeticParamsOrder -OutputFolder .\docs\Module -WithModulePage  -Locale en-US
```

* remove Comment Based Help from psm1
* Adjust the markdown files.

```powershell
Update-MarkdownHelpModule -Path .\docs\Module\ -RefreshModulePage -Verbose -AlphabeticParamsOrder
```

* Update the Module page


This will need to be added to the build.ps1 once it is merged:

```powershell
New-ExternalHelp -OutputPath .\WinCompatibilityPack\bin\release\netstandard2.0\publish\ -Path .\docs\Module\
```