### PR TITLE
Disabled the ability to do Import-WinModule Microsoft.PowerShell.Management module

### DIFF
--- a/Tests/CompatibilitySession.Tests.ps1
+++ b/Tests/CompatibilitySession.Tests.ps1
@@ -65,6 +65,9 @@ Describe "Test the Windows PowerShell Compatibility Session functions" {
         Get-Module PnpDevice | Remove-Module
     }
 
+    <##################################
+     # Disabled until we have a way to import modules with a different name
+
     It "Import-WinModule Microsoft.PowerShell.Management should import new commands but not overwrite existing ones" {
         # Remove the proxy module if present
         Get-Module Microsoft.PowerShell.Management |
@@ -83,7 +86,7 @@ Describe "Test the Windows PowerShell Compatibility Session functions" {
         $ele | Should -Not -BeNullOrEmpty
         $ele.PSObject.TypeNames -eq 'Deserialized.System.Diagnostics.EventLogEntry' | Should -Be Deserialized.System.Diagnostics.EventLogEntry
     }
-
+#############################################>
     It "Add-WinFunction should define a function in the current session and return information from the compatibility session" {
         Remove-Item -ErrorAction Ignore function:myFunction
         Add-WinFunction myFunction {param ($n) "Hi $n!"; $PSVersionTable.PSEdition }

--- a/WinCompatibilityPack/WinCompatibilityPack.psm1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psm1
@@ -15,7 +15,14 @@ $NeverImportList = @(
     "PowerShellGet",
     "Microsoft.PowerShell.Archive",
     "Microsoft.PowerShell.Host",
-    "WinCompatibilityPack"
+    "WinCompatibilityPack",
+    # The following modules contain useful additional commands but importing them
+    # as script modules (along with the original module) breaks file completion
+    # so until we have a way to import them with a different module name, they're blocked
+    "Microsoft.PowerShell.Management",
+    "Microsoft.PowerShell.Utility",
+    "Microsoft.PowerShell.Security",
+    "Microsoft.PowerShell.Diagnostics"
 )
 
 ###########################################################################################
@@ -23,10 +30,12 @@ $NeverImportList = @(
 # the functionality of Windows PowerShell 5.1 versions. These modules can be imported but
 # will not overwrite any existing PowerShell Core commands
 $NeverClobberList = @(
+    <# Until there is a mechanism for importing a module with a different name, these modules are blocked
     "Microsoft.PowerShell.Management",
     "Microsoft.PowerShell.Utility",
     "Microsoft.PowerShell.Security",
     "Microsoft.PowerShell.Diagnostics"
+    #>
 )
 
 ###########################################################################################
@@ -468,13 +477,6 @@ function Get-WinModule
     Import-WinModule PnpDevice; Get-Command -Module PnpDevice
 
     This example imports the 'PnpDevice' module.
-.EXAMPLE
-    Import-WinModule Microsoft.PowerShell.Management; Get-Command Get-EventLog
-
-    This example imports one of the core Windows PowerShell modules
-    containing commands not natively available in PowerShell Core such
-    as 'Get-EventLog'. Only commands not already present in PowerShell Core
-    will be imported.
 .EXAMPLE
     Import-WinModule PnpDevice -Verbose -Force
 


### PR DESCRIPTION
Fix for #7. Disabled the test using the Microsoft.PowerShell.Management module and blocked Import-WinModule from importing it.

Loading the proxy module resulted in module-qualified commands resolving to the proxy instead
of the original module. This broke file-name completion (and probably other things we didn't notice
as quickly.)