### PR TITLE
Add Module Rename Hack

### DIFF
--- a/WinCompatibilityPack/WinCompatibilityPack.psm1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psm1
@@ -485,10 +485,9 @@ function Import-WinModule
             { 
                 $module = Import-Module -Name $name -NoClobber @importModuleParameters 
                 # Hack using private reflection to keep the proxy module from shadowing the real module.
-                $null = $module.
-                    GetType().
-                        GetMethod("SetName",[System.Reflection.BindingFlags]'Instance, NonPublic').
-                            Invoke($module, @($module.Name + ".WinModule"))
+                $null = [PSModuleInfo].
+                    GetMethod('SetName',[System.Reflection.BindingFlags]'Instance, NonPublic').
+                        Invoke($module, @($module.Name + '.WinModule'))
                 if($PassThru.IsPresent)
                 {
                     $module

--- a/WinCompatibilityPack/WinCompatibilityPack.psm1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psm1
@@ -480,7 +480,20 @@ function Import-WinModule
         }
         if ($noClobberNames)
         {
-            Import-Module  -Name $noClobberNames -NoClobber @importModuleParameters
+            $importModuleParameters.PassThru = $true 
+            foreach ($name in $noClobberNames) 
+            { 
+                $module = Import-Module -Name $name -NoClobber @importModuleParameters 
+                # Hack using private reflection to keep the proxy module from shadowing the real module.
+                $module.
+                    GetType().
+                        GetMethod("SetName",[System.Reflection.BindingFlags]'Instance, NonPublic').
+                            Invoke($module, @($module.Name + ".WinModule"))
+                if($PassThru.IsPresent)
+                {
+                    $module
+                }
+            }
         }
     }
     else

--- a/WinCompatibilityPack/WinCompatibilityPack.psm1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psm1
@@ -485,7 +485,7 @@ function Import-WinModule
             { 
                 $module = Import-Module -Name $name -NoClobber @importModuleParameters 
                 # Hack using private reflection to keep the proxy module from shadowing the real module.
-                $module.
+                $null = $module.
                     GetType().
                         GetMethod("SetName",[System.Reflection.BindingFlags]'Instance, NonPublic').
                             Invoke($module, @($module.Name + ".WinModule"))


### PR DESCRIPTION
* Closes #7
* Adds the module rename hack
* Added logic to pass through the renamed module if `-PassThru` was supplied
* Assigns the Hack operation to `$null` (otherwise output is polluted)