### PR TITLE
Set required (minimum) PowerShell version to be 6.0

### DIFF
--- a/WinCompatibilityPack/WinCompatibilityPack.psd1
+++ b/WinCompatibilityPack/WinCompatibilityPack.psd1
@@ -19,7 +19,7 @@ invoke commands that are only available in Windows PowerShell. These utilities h
 to discover available modules, import those modules through proxies and then use the module
 commands much as if they were native to PowerShell Core.
 '@
-PowerShellVersion = '5.1'
+PowerShellVersion = '6.0'
 FunctionsToExport = @(
     'Initialize-WinSession',
     'Add-WinFunction',


### PR DESCRIPTION
Since we aren't enforcing `CompatiblePSEditions` yet, setting the minimum required PowerShell version to 6.0 will block the module from being loaded on `Desktop` (PowerShell 5.1).